### PR TITLE
Add deprecated current control type

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Precision could be specified in ```precision``` property. The value is rounded t
 | Gas concentration | concentration | ppm  | float (unsigned) |
 | Heat power | heat_power | Gcal / hour | float |
 | Heat energy | heat_energy | Gcal | float |
+| Current | current | A | float |
+
 
 #### Units
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+Conventions (1.3.1) stable; urgency=medium
+
+  * Add deprecated current control type 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 03 Nov 2023 10:38:55 +0500
+
 Conventions (1.3.0) stable; urgency=medium
 
   * Add ppm, ppb units for MSW VOC sensor


### PR DESCRIPTION
В шаблонах активно используется тип `current`, но он не описан