### PR TITLE
Add missed control types

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Precision could be specified in ```precision``` property. The value is rounded t
 | Heat power | heat_power | Gcal / hour | float |
 | Heat energy | heat_energy | Gcal | float |
 | Current | current | A | float |
+| Pressure | pressure | bar | float |
+| Illuminance | lux | lx | float |
+| Sound level | sound_level | dB | float |
 
 #### Units
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,15 @@
+Conventions (1.3.4) stable; urgency=medium
+
+  * Add deprecated pressure, lux, sound_level control types
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 08 May 2024 18:30:00 +0400
+
+Conventions (1.3.3) stable; urgency=medium
+
+  * Add enum control type
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 12 Mar 2024 10:58:00 +0400
+
 Conventions (1.3.2) stable; urgency=medium
 
   * Add default values for meta


### PR DESCRIPTION
В шаблонах используются, но не описаны

https://github.com/wirenboard/homeui/blob/c96ec9445e24e8718ba83cb971e5512a49bffcb6/app/scripts/services/devicedata.js#L41