### PR TITLE
fix: add WB 2024 naming convention MQTT topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 The basic abstractions are *devices* and their *controls*. 
 
-Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored. *Devices* and *controls* are identified by names (arbitrary strings), and have some metadata. Metadata messages are published on device startup with `retained` flag set.
+Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored.
+*Devices* and *controls* are identified by names, which are generally arbitrary strings.
+
+Starting from 2024, WirenBoard has established the following rules for naming new device and control MQTT topics:
+- The topic name cannot include punctuation, brackets, or special characters such as %$#& etc.
+- For a new device, the topic name should not contain more than four words and numbers. Write each word in lowercase and separate them with underscores.
+- For a new version of an existing device, make the topics compatible with the old pattern (marked as deprecated). The names of new topics should be styled identically to the existing topics.
+
+Each MQTT topic has some metadata.
+Metadata messages are published on device startup with `retained` flag set.
 For example, some room lighting control *device* with one input (for wall switch) and one output (for controlling the lamp) *controls* is represented with MQTT topics as following:
 
 * `/devices/RoomLight/meta` - JSON with all meta information about *device*

--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@ The basic abstractions are *devices* and their *controls*.
 Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored.
 *Devices* and *controls* are identified by names, which are generally arbitrary strings.
 
-Starting from 2024, WirenBoard has established the following rules for naming new device and control MQTT topics:
+Starting from 2024, WirenBoard has established the following rules for naming MQTT topics for new devices and their controls:
 - The topic name cannot include punctuation, brackets, or special characters such as %$#& etc.
 - For a new device, the topic name should not contain more than four words and numbers. Write each word in lowercase and separate them with underscores.
 - For a new version of an existing device, make the topics compatible with the old pattern (marked as deprecated). The names of new topics should be styled identically to the existing topics.
 
-Each MQTT topic has some metadata.
+Examples:
+- Good: `/devices/room_light/meta`
+- Bad: `/devices/Room-Light#1/meta`
+- Old: `/devices/RoomLight/meta` - not recommended for new topics
+
+The metadata is published exclusively in the `*/meta` topics and their subtopics.
 Metadata messages are published on device startup with `retained` flag set.
 For example, some room lighting control *device* with one input (for wall switch) and one output (for controlling the lamp) *controls* is represented with MQTT topics as following:
 


### PR DESCRIPTION
Добавил конвенцию названия имен, чтобы можно было ссылаться на это публичное место в переписках с клиентами