### PR TITLE
Revise MQTT topic naming conventions to snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The basic abstractions are *devices* and their *controls*. 
 
-All devices must be located at the root level of the MQTT broker under the `/devices/..` topic (e.g., `/devices/device_name/...`).
+All devices must be located at the root level of the MQTT broker under the `/devices/..` topic (e.g., `/devices/<!new_device_name!>/...`).
 
 Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored.
 *Devices* and *controls* are identified by names, which are generally arbitrary strings.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 The basic abstractions are *devices* and their *controls*. 
 
-### Root Path
+#### Root Path
 
 All devices must be located at the root level of the MQTT broker under the `/devices/...` topic (e.g., `/devices/<!new_device_name!>/...`).
 
 Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored.
 *Devices* and *controls* are identified by names, which are generally arbitrary strings.
 
-### Naming Conventions (2024+)
+#### Naming Conventions (2024+)
 
 Starting from 2024, WirenBoard has established the following rules for naming MQTT topics for new devices and their controls:
 - The topic name cannot include punctuation, brackets, or special characters such as %$#& etc.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
 ## Wiren Board MQTT Conventions
 
+### Basic Concepts
+
 The basic abstractions are *devices* and their *controls*. 
 
-All devices must be located at the root level of the MQTT broker under the `/devices/..` topic (e.g., `/devices/<!new_device_name!>/...`).
+### Topic Structure & Root Path
+
+All devices must be located at the root level of the MQTT broker under the `/devices/...` topic (e.g., `/devices/<!new_device_name!>/...`).
 
 Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored.
 *Devices* and *controls* are identified by names, which are generally arbitrary strings.
+
+### Naming Conventions (2024+)
 
 Starting from 2024, WirenBoard has established the following rules for naming MQTT topics for new devices and their controls:
 - The topic name cannot include punctuation, brackets, or special characters such as %$#& etc.
 - For a new device, the topic name should not contain more than four words and numbers. Write each word in lowercase and separate them with underscores.
 - For a new version of an existing device, make the topics compatible with the old pattern (marked as deprecated). The names of new topics should be styled identically to the existing topics.
 
-Examples:
+**Examples:**
 - Good: `/devices/room_light/meta`
 - Bad: `/devices/Room-Light#1/meta`
 - Old: `/devices/RoomLight/meta` - not recommended for new topics
 
+### Metadata Publishing
+
 The metadata is published exclusively in the `*/meta` topics and their subtopics.
 Metadata messages are published on device startup with `retained` flag set.
+
+### Example: Device and Controls Hierarchy
 For example, some room lighting control *device* with one input (for wall switch) and one output (for controlling the lamp) *controls* is represented with MQTT topics as following:
 
 * `/devices/room_light/meta` - JSON with all meta information about *device*

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For example, some room lighting control *device* with one input (for wall switch
 * `/devices/room_light/controls/lamp/meta` - JSON with all meta information about control
 * `/devices/room_light/controls/switch` - contains current wall switch state
 * `/devices/room_light/controls/switch/meta` - JSON with all meta information about control
-* `/devices/room_light/controls/switch/meta/error` - non-null value means there was an error reading or writing the control. In this case  `/devices/room_light/controls/Switch` contains last known good value.
+* `/devices/room_light/controls/switch/meta/error` - non-null value means there was an error reading or writing the control. In this case  `/devices/room_light/controls/switch` contains last known good value.
 
 Each *device* usually represents the single physical device or one of the integrated peripheral of a complex physical device, although there are some boundary cases where the distinction is not clear. The small and not-so-complex real-world devices (say, wireless weather sensor) are ought to be represented by a single *device* in the MQTT hierarchy. 
 Each *device* must be handled by a single driver or publisher, though it's not enforced in any way.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 ## Wiren Board MQTT Conventions
 
-### Basic Concepts
+### 1. Basic Concepts
 
 The basic abstractions are *devices* and their *controls*. 
 
-#### Root Path
+#### 1.1. Root Path
 
 All devices must be located at the root level of the MQTT broker under the `/devices/...` topic (e.g., `/devices/<!new_device_name!>/...`).
 
 Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored.
 *Devices* and *controls* are identified by names, which are generally arbitrary strings.
 
-#### Naming Conventions (2024+)
+#### 1.2. Naming Conventions (2024+)
 
 Starting from 2024, WirenBoard has established the following rules for naming MQTT topics for new devices and their controls:
 - The topic name cannot include punctuation, brackets, or special characters such as %$#& etc.
@@ -23,7 +23,7 @@ Examples:
 - Bad: `/devices/Room-Light#1/meta`
 - Old: `/devices/RoomLight/meta` - not recommended for new topics
 
-### Device and Controls Hierarchy example
+#### 1.3. Device and Controls Hierarchy example
 For example, some room lighting control *device* with one input (for wall switch) and one output (for controlling the lamp) *controls* is represented with MQTT topics as following:
 
 * `/devices/room_light/meta` - JSON with all meta information about *device*
@@ -40,12 +40,12 @@ Each *device* must be handled by a single driver or publisher, though it's not e
 
 The *Conventions* are based on [HomA MQTT Conventions](https://github.com/binarybucks/homA/wiki/Conventions). The main changes are: no configuration is stored in MQTT (as MQTT is not so good as a database) and the *control* types system is more developed and complicated.
 
-### Metadata Publishing
+### 2. Metadata Publishing
 
 The metadata is published exclusively in the `*/meta` topics and their subtopics.
 Metadata messages are published on device startup with `retained` flag set.
 
-#### Device's `/meta` topic
+#### 2.1. Device's `/meta` topic
 
 The topic contains all meta information in one JSON
 
@@ -62,7 +62,7 @@ The topic contains all meta information in one JSON
 English title could be published in `/devices/+/meta/name` for backward compatibility with old conventions.
 
 
-#### Controls's `/meta` topic
+#### 2.2. Controls's `/meta` topic
 
 The topic contains all meta information in one JSON
 
@@ -116,7 +116,7 @@ The topic contains all meta information in one JSON
 
 `type`, `min`, `max`, `order`, `readonly` could be published as subtopics of `/devices/+/controls/+/meta` for backward compatibility with old conventions.
 
-### Control Types
+### 3. Control Types
 
 #### Switch
 A control that toggles it's value when pressed by the user.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The basic abstractions are *devices* and their *controls*. 
 
-### Topic Structure & Root Path
+### Root Path
 
 All devices must be located at the root level of the MQTT broker under the `/devices/...` topic (e.g., `/devices/<!new_device_name!>/...`).
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Starting from 2024, WirenBoard has established the following rules for naming MQ
 - For a new device, the topic name should not contain more than four words and numbers. Write each word in lowercase and separate them with underscores.
 - For a new version of an existing device, make the topics compatible with the old pattern (marked as deprecated). The names of new topics should be styled identically to the existing topics.
 
-**Examples:**
+Examples:
 - Good: `/devices/room_light/meta`
 - Bad: `/devices/Room-Light#1/meta`
 - Old: `/devices/RoomLight/meta` - not recommended for new topics
 
-### Example: Device and Controls Hierarchy
+### Device and Controls Hierarchy example
 For example, some room lighting control *device* with one input (for wall switch) and one output (for controlling the lamp) *controls* is represented with MQTT topics as following:
 
 * `/devices/room_light/meta` - JSON with all meta information about *device*

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ Starting from 2024, WirenBoard has established the following rules for naming MQ
 - Bad: `/devices/Room-Light#1/meta`
 - Old: `/devices/RoomLight/meta` - not recommended for new topics
 
-### Metadata Publishing
-
-The metadata is published exclusively in the `*/meta` topics and their subtopics.
-Metadata messages are published on device startup with `retained` flag set.
-
 ### Example: Device and Controls Hierarchy
 For example, some room lighting control *device* with one input (for wall switch) and one output (for controlling the lamp) *controls* is represented with MQTT topics as following:
 
@@ -45,7 +40,12 @@ Each *device* must be handled by a single driver or publisher, though it's not e
 
 The *Conventions* are based on [HomA MQTT Conventions](https://github.com/binarybucks/homA/wiki/Conventions). The main changes are: no configuration is stored in MQTT (as MQTT is not so good as a database) and the *control* types system is more developed and complicated.
 
-### Device's `/meta` topic
+### Metadata Publishing
+
+The metadata is published exclusively in the `*/meta` topics and their subtopics.
+Metadata messages are published on device startup with `retained` flag set.
+
+#### Device's `/meta` topic
 
 The topic contains all meta information in one JSON
 
@@ -62,7 +62,7 @@ The topic contains all meta information in one JSON
 English title could be published in `/devices/+/meta/name` for backward compatibility with old conventions.
 
 
-### Controls's `/meta` topic
+#### Controls's `/meta` topic
 
 The topic contains all meta information in one JSON
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ For example, some room lighting control *device* with one input (for wall switch
 
 * `/devices/room_light/meta` - JSON with all meta information about *device*
 * `/devices/room_light/meta/error` - device-level error state, non-null means there was an error (usable as Last Will and Testament)
-* `/devices/room_light/controls/Lamp` - contains current lamp state, '0' = off, '1' = on
-* `/devices/room_light/controls/Lamp/on` - send a message with this topic and payload of '0'/'1' to turn lamp off or on
-* `/devices/room_light/controls/Lamp/meta` - JSON with all meta information about control
-* `/devices/room_light/controls/Switch` - contains current wall switch state
-* `/devices/room_light/controls/Switch/meta` - JSON with all meta information about control
-* `/devices/room_light/controls/Switch/meta/error` - non-null value means there was an error reading or writing the control. In this case  `/devices/room_light/controls/Switch` contains last known good value.
+* `/devices/room_light/controls/lamp` - contains current lamp state, '0' = off, '1' = on
+* `/devices/room_light/controls/lamp/on` - send a message with this topic and payload of '0'/'1' to turn lamp off or on
+* `/devices/room_light/controls/lamp/meta` - JSON with all meta information about control
+* `/devices/room_light/controls/switch` - contains current wall switch state
+* `/devices/room_light/controls/switch/meta` - JSON with all meta information about control
+* `/devices/room_light/controls/switch/meta/error` - non-null value means there was an error reading or writing the control. In this case  `/devices/room_light/controls/Switch` contains last known good value.
 
 Each *device* usually represents the single physical device or one of the integrated peripheral of a complex physical device, although there are some boundary cases where the distinction is not clear. The small and not-so-complex real-world devices (say, wireless weather sensor) are ought to be represented by a single *device* in the MQTT hierarchy. 
 Each *device* must be handled by a single driver or publisher, though it's not enforced in any way.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The basic abstractions are *devices* and their *controls*. 
 
+All devices must be located at the root level of the MQTT broker under the `/devices/..` topic (e.g., `/devices/device_name/...`).
+
 Each *device* has some *controls* assigned to it, i.e. parameters that can be controlled or monitored.
 *Devices* and *controls* are identified by names, which are generally arbitrary strings.
 
@@ -19,14 +21,14 @@ The metadata is published exclusively in the `*/meta` topics and their subtopics
 Metadata messages are published on device startup with `retained` flag set.
 For example, some room lighting control *device* with one input (for wall switch) and one output (for controlling the lamp) *controls* is represented with MQTT topics as following:
 
-* `/devices/RoomLight/meta` - JSON with all meta information about *device*
-* `/devices/RoomLight/meta/error` - device-level error state, non-null means there was an error (usable as Last Will and Testament)
-* `/devices/RoomLight/controls/Lamp` - contains current lamp state, '0' = off, '1' = on
-* `/devices/RoomLight/controls/Lamp/on` - send a message with this topic and payload of '0'/'1' to turn lamp off or on
-* `/devices/RoomLight/controls/Lamp/meta` - JSON with all meta information about control
-* `/devices/RoomLight/controls/Switch` - contains current wall switch state
-* `/devices/RoomLight/controls/Switch/meta` - JSON with all meta information about control
-* `/devices/RoomLight/controls/Switch/meta/error` - non-null value means there was an error reading or writing the control. In this case  `/devices/RoomLight/controls/Switch` contains last known good value.
+* `/devices/room_light/meta` - JSON with all meta information about *device*
+* `/devices/room_light/meta/error` - device-level error state, non-null means there was an error (usable as Last Will and Testament)
+* `/devices/room_light/controls/Lamp` - contains current lamp state, '0' = off, '1' = on
+* `/devices/room_light/controls/Lamp/on` - send a message with this topic and payload of '0'/'1' to turn lamp off or on
+* `/devices/room_light/controls/Lamp/meta` - JSON with all meta information about control
+* `/devices/room_light/controls/Switch` - contains current wall switch state
+* `/devices/room_light/controls/Switch/meta` - JSON with all meta information about control
+* `/devices/room_light/controls/Switch/meta/error` - non-null value means there was an error reading or writing the control. In this case  `/devices/room_light/controls/Switch` contains last known good value.
 
 Each *device* usually represents the single physical device or one of the integrated peripheral of a complex physical device, although there are some boundary cases where the distinction is not clear. The small and not-so-complex real-world devices (say, wireless weather sensor) are ought to be represented by a single *device* in the MQTT hierarchy. 
 Each *device* must be handled by a single driver or publisher, though it's not enforced in any way.


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

1) Добавил явное упоминание того что все девайсы по конвенции должны находиться именно внутри топика девайсов. В явном виде это не было указано раньше и можно было иметь разночтения.
2) Обновил MQTT topic naming conventions для девайсов в snake_case вместо camelCase.

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


